### PR TITLE
Fix biometrics button showing when BiometricsLocalDataSource is null

### DIFF
--- a/packages/widget_toolkit_pin/CHANGELOG.md
+++ b/packages/widget_toolkit_pin/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.2-dev.4]
+* Fix biometrics button being displayed when `biometricsLocalDataSource` is not provided
+* Update dependencies 
 ## [0.0.2-dev.3]
 * Remove `isAuthenticatedWithBiometrics` and `isPinCodeVerified` callbacks.
 * Add `onAuthenticated` callback.

--- a/packages/widget_toolkit_pin/CHANGELOG.md
+++ b/packages/widget_toolkit_pin/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [0.0.2-dev.4]
 * Fix biometrics button being displayed when `biometricsLocalDataSource` is not provided
 * Update dependencies 
+
 ## [0.0.2-dev.3]
 * Remove `isAuthenticatedWithBiometrics` and `isPinCodeVerified` callbacks.
 * Add `onAuthenticated` callback.

--- a/packages/widget_toolkit_pin/example/pubspec.yaml
+++ b/packages/widget_toolkit_pin/example/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
   sdk: ">=3.0.5 <4.0.0"
 
 dependencies:
-  shared_preferences: ^2.2.0
+  shared_preferences: ^2.2.1
   flutter:
     sdk: flutter
   flutter_rx_bloc: ^6.0.0
   provider: ^6.0.5
   rx_bloc: ^5.0.0
-  widget_toolkit: ^0.0.1-dev10
-  widget_toolkit_pin: ^0.0.2-dev.1
+  widget_toolkit: ^0.0.2-dev.1
+  widget_toolkit_pin: ^0.0.2-dev.3
   widget_toolkit_biometrics: ^0.0.2-dev.1
 
 dev_dependencies:

--- a/packages/widget_toolkit_pin/lib/src/lib_pin_code_with_biometrics/ui_components/pin_code_component.dart
+++ b/packages/widget_toolkit_pin/lib/src/lib_pin_code_with_biometrics/ui_components/pin_code_component.dart
@@ -419,24 +419,30 @@ class _PinCodeComponentState extends State<PinCodeComponent>
     BuildContext context,
     int pinLength,
   ) =>
-      SizedBox(
-        height: calculateKeyboardButtonSize(context),
-        width: calculateKeyboardButtonSize(context),
-        child: Center(
-          child: widget.bottomRightKeyboardButton ??
-              AnimatedSwitcher(
-                duration: const Duration(milliseconds: 300),
-                child: RxBlocBuilder<PinCodeBlocType, bool>(
-                  state: (bloc) => bloc.states.showBiometricsButton,
-                  builder: (context, showButton, bloc) => _buildButtonContent(
-                    context,
-                    showButton.hasData && showButton.data!,
-                    pinLength,
-                  ),
-                ),
+      widget.biometricsLocalDataSource == null
+          ? SizedBox(
+              height: calculateKeyboardButtonSize(context),
+              width: calculateKeyboardButtonSize(context),
+            )
+          : SizedBox(
+              height: calculateKeyboardButtonSize(context),
+              width: calculateKeyboardButtonSize(context),
+              child: Center(
+                child: widget.bottomRightKeyboardButton ??
+                    AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 300),
+                      child: RxBlocBuilder<PinCodeBlocType, bool>(
+                        state: (bloc) => bloc.states.showBiometricsButton,
+                        builder: (context, showButton, bloc) =>
+                            _buildButtonContent(
+                          context,
+                          showButton.hasData && showButton.data!,
+                          pinLength,
+                        ),
+                      ),
+                    ),
               ),
-        ),
-      );
+            );
 
   Widget _buildButtonContent(
     BuildContext context,

--- a/packages/widget_toolkit_pin/lib/src/lib_pin_code_with_biometrics/ui_components/pin_code_component.dart
+++ b/packages/widget_toolkit_pin/lib/src/lib_pin_code_with_biometrics/ui_components/pin_code_component.dart
@@ -419,30 +419,24 @@ class _PinCodeComponentState extends State<PinCodeComponent>
     BuildContext context,
     int pinLength,
   ) =>
-      widget.biometricsLocalDataSource == null
-          ? SizedBox(
-              height: calculateKeyboardButtonSize(context),
-              width: calculateKeyboardButtonSize(context),
-            )
-          : SizedBox(
-              height: calculateKeyboardButtonSize(context),
-              width: calculateKeyboardButtonSize(context),
-              child: Center(
-                child: widget.bottomRightKeyboardButton ??
-                    AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 300),
-                      child: RxBlocBuilder<PinCodeBlocType, bool>(
-                        state: (bloc) => bloc.states.showBiometricsButton,
-                        builder: (context, showButton, bloc) =>
-                            _buildButtonContent(
-                          context,
-                          showButton.hasData && showButton.data!,
-                          pinLength,
-                        ),
-                      ),
-                    ),
+      SizedBox(
+        height: calculateKeyboardButtonSize(context),
+        width: calculateKeyboardButtonSize(context),
+        child: Center(
+          child: widget.bottomRightKeyboardButton ??
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 300),
+                child: RxBlocBuilder<PinCodeBlocType, bool>(
+                  state: (bloc) => bloc.states.showBiometricsButton,
+                  builder: (context, showButton, bloc) => _buildButtonContent(
+                    context,
+                    showButton.hasData && showButton.data!,
+                    pinLength,
+                  ),
+                ),
               ),
-            );
+        ),
+      );
 
   Widget _buildButtonContent(
     BuildContext context,
@@ -500,7 +494,7 @@ class _PinCodeComponentState extends State<PinCodeComponent>
     BuildContext context,
     bool showBiometricsButton,
   ) =>
-      (showBiometricsButton)
+      (widget.biometricsLocalDataSource != null && showBiometricsButton)
           ? PinCodeBiometricKey(
               isLoading: isLoading,
               onPressedDefault: (_) => context

--- a/packages/widget_toolkit_pin/pubspec.yaml
+++ b/packages/widget_toolkit_pin/pubspec.yaml
@@ -1,8 +1,8 @@
 name: widget_toolkit_pin
-description: This package provide out of the box entering PIN code functionality, which can be used 
-  with biometric authentication.
+description: This package provide out of the box entering PIN code
+  functionality, which can be used with biometric authentication.
 
-version: 0.0.2-dev.3
+version: 0.0.2-dev.4
 homepage: https://primeholding.com/
 
 environment:
@@ -10,17 +10,17 @@ environment:
   flutter: ">=3.10.5"
 
 dependencies:
-  app_settings: ^5.0.0
+  app_settings: ^5.1.1
   flutter:
     sdk: flutter
   flutter_rx_bloc: ^6.0.0
   flutter_svg: ^2.0.7
-  local_auth: ^2.1.6
+  local_auth: ^2.1.7
   provider: ^6.0.5
   rx_bloc: ^5.0.0
   rx_bloc_list: ^4.0.0
   rxdart: ^0.27.7
-  shared_preferences: ^2.2.0
+  shared_preferences: ^2.2.1
   theme_tailor_annotation: ^2.0.0
   widget_toolkit: ^0.0.2-dev.1
   widget_toolkit_biometrics: ^0.0.2-dev.1
@@ -28,7 +28,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.6
   clean_coverage: ^0.0.3
-  flutter_lints: ^2.0.1
+  flutter_lints: ^2.0.3
   flutter_test:
     sdk: flutter
   golden_toolkit: ^0.15.0


### PR DESCRIPTION
This PR should fix the biometrics button being displayed when it's not supposed to be.
This was deleted during the last refactoring of widget_toolkit_pin