### PR TITLE
Removed `isPinCodeInSecureStorage` method from `PinCodeService`. Now …

### DIFF
--- a/packages/widget_toolkit_pin/CHANGELOG.md
+++ b/packages/widget_toolkit_pin/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [0.3.0]
 * Added `savePinCodeInSecureStorage` to `PinCodeService` for saving the pin code in secure storage
 * Added `autoPromptBiometric` parameter to `PinCodeKeyboard` to automatically authenticate with biometrics if available
+* Removed `isPinCodeInSecureStorage` method from `PinCodeService`. Now this flag is set automatically when the pin code is saved in secure storage and accessed through the `getPinCode` method
 * Fixed a bug where biometrics authentication would not work if encryption was used
 * Added biometrics authentication to the example application
 

--- a/packages/widget_toolkit_pin/README.md
+++ b/packages/widget_toolkit_pin/README.md
@@ -107,15 +107,7 @@ class AppPinCodeService implements PinCodeService {
   static const _isPinCodeInStorage = 'pinCode';
 
   FlutterSecureStorage get flutterSecureStorage => const FlutterSecureStorage();
-
-  @override
-  Future<bool> isPinCodeInSecureStorage() async {
-    var isPinCodeInSecureStorage =
-      await flutterSecureStorage.read(key: _isPinCodeInStorage);
-
-    return isPinCodeInSecureStorage != null;
-  }
-
+  
   @override
   Future<String> encryptPinCode(String pinCode) async {
     // App specific encryption
@@ -192,7 +184,7 @@ mapBiometricMessageToString: (message) {
 
 Optionally you can provide `onError` to handle errors out of the package, or to show a notification,
 in practice this would only get called if the implementations of `BiometricsLocalDataSource.areBiometricsEnabled()`, 
-`BiometricsLocalDataSource.setBiometricsEnabled(enable)`,`PinCodeService.isPinCodeInSecureStorage()`, 
+`BiometricsLocalDataSource.setBiometricsEnabled(enable)`, 
 `PinCodeService.encryptPinCode()`, `PinCodeService.getPinLength()`, `PinCodeService.verifyPinCode()`, 
 `PinCodeService.getPinCode()`, throw.
 

--- a/packages/widget_toolkit_pin/example/lib/main.dart
+++ b/packages/widget_toolkit_pin/example/lib/main.dart
@@ -97,7 +97,7 @@ class MyHomePage extends StatelessWidget {
                       // or to show a notification, in practice this would only get called if the
                       // implementations of [BiometricsLocalDataSource.areBiometricsEnabled()],
                       // [BiometricsLocalDataSource.setBiometricsEnabled(enable)],
-                      // [PinCodeService.isPinCodeInSecureStorage()], [PinCodeService.encryptPinCode()],
+                      // [PinCodeService.encryptPinCode()],
                       // [PinCodeService.getPinLength()], [PinCodeService.verifyPinCode()],
                       // [PinCodeService.getPinCode()], throw.
                       onError: (error, translatedError) =>
@@ -164,14 +164,6 @@ class AppPinCodeService implements PinCodeService {
   /// This pin is intended to be stored in the secured storage for production
   /// applications
   final String _pinCode = '1111';
-
-  @override
-  Future<bool> isPinCodeInSecureStorage() async {
-    if (_pinCode == '1111') {
-      return Future.value(true);
-    }
-    return Future.value(false);
-  }
 
   @override
   Future<String> encryptPinCode(String pinCode) async {

--- a/packages/widget_toolkit_pin/lib/src/lib_pin_code_with_biometrics/services/pin_code_service.dart
+++ b/packages/widget_toolkit_pin/lib/src/lib_pin_code_with_biometrics/services/pin_code_service.dart
@@ -1,8 +1,4 @@
 abstract class PinCodeService {
-  /// Reads from device internal storage and
-  /// returns the stored pin code to the bloc
-  Future<bool> isPinCodeInSecureStorage();
-
   /// Receives the encrypted pinCode from user input.
   /// Returns the value verified by the server
   Future<dynamic> verifyPinCode(String pinCode);
@@ -12,7 +8,7 @@ abstract class PinCodeService {
   Future<int> getPinLength();
 
   /// Encrypts the provided pin code and returns the encrypted string. It has a
-  /// default implementation to return what is the input. 
+  /// default implementation to return what is the input.
   Future<String> encryptPinCode(String pinCode) => Future.value(pinCode);
 
   /// Returns the pin code or null if it is not saved in the device memory yet.

--- a/packages/widget_toolkit_pin/test/lib_pin_code/blocs/pin_code_test.dart
+++ b/packages/widget_toolkit_pin/test/lib_pin_code/blocs/pin_code_test.dart
@@ -30,7 +30,6 @@ void main() {
     List<BiometricsAuthType>? biometrics,
     String pinCode = '',
     bool isPinVerified = true,
-    bool isPinCodeInSecureStorage = true,
     bool enableBiometrics = true,
     BiometricsMessage biometricsMessage = BiometricsMessage.enabled,
     ErrorModel? biometricsError,
@@ -61,9 +60,6 @@ void main() {
 
     when(pinCodeService.verifyPinCode(pinCode))
         .thenAnswer((_) => Future.value(isPinVerified));
-
-    when(pinCodeService.isPinCodeInSecureStorage())
-        .thenAnswer((_) => Future.value(isPinCodeInSecureStorage));
 
     when(pinCodeService.encryptPinCode(pinCode))
         .thenAnswer((_) => Future.value(pinCode));
@@ -135,7 +131,6 @@ void main() {
         build: () async {
           defineWhen(
             isDeviceSupported: true,
-            isPinCodeInSecureStorage: true,
             isPinVerified: true,
             canCheckBiometrics: true,
             pinCode: Stubs.pinCode,
@@ -157,7 +152,6 @@ void main() {
             pinCode: Stubs.pinCode,
             isPinVerified: true,
             enableBiometrics: true,
-            isPinCodeInSecureStorage: true,
           );
 
           return pinCodeBloc();
@@ -174,7 +168,6 @@ void main() {
           defineWhen(
             pinCode: Stubs.pinCode2,
             isPinVerified: false,
-            isPinCodeInSecureStorage: false,
             areBiometricsEnabled: false,
           );
 
@@ -190,7 +183,6 @@ void main() {
           defineWhen(
             pinCode: Stubs.pinCode2,
             isPinVerified: false,
-            isPinCodeInSecureStorage: false,
             areBiometricsEnabled: false,
             biometricsError: Stubs.error,
           );

--- a/packages/widget_toolkit_pin/test/lib_pin_code/blocs/pin_code_test.mocks.dart
+++ b/packages/widget_toolkit_pin/test/lib_pin_code/blocs/pin_code_test.mocks.dart
@@ -147,15 +147,6 @@ class MockPinCodeService extends _i1.Mock implements _i7.PinCodeService {
   }
 
   @override
-  _i4.Future<bool> isPinCodeInSecureStorage() => (super.noSuchMethod(
-        Invocation.method(
-          #isPinCodeInSecureStorage,
-          [],
-        ),
-        returnValue: _i4.Future<bool>.value(false),
-      ) as _i4.Future<bool>);
-
-  @override
   _i4.Future<dynamic> verifyPinCode(String? pinCode) => (super.noSuchMethod(
         Invocation.method(
           #verifyPinCode,
@@ -196,4 +187,14 @@ class MockPinCodeService extends _i1.Mock implements _i7.PinCodeService {
         ),
         returnValue: _i4.Future<String?>.value(),
       ) as _i4.Future<String?>);
+
+  @override
+  _i4.Future<bool> savePinCodeInSecureStorage(String? pinCode) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #savePinCodeInSecureStorage,
+          [pinCode],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
 }

--- a/packages/widget_toolkit_pin/test/mocks/pin_code_mock.dart
+++ b/packages/widget_toolkit_pin/test/mocks/pin_code_mock.dart
@@ -35,7 +35,7 @@ PinCodeBlocType pinCodeMockFactory({
   when(statesMock.showBiometricsButton).thenAnswer(
     (_) {
       service.verifyPinCode(Stubs.pinCode3);
-      service.isPinCodeInSecureStorage();
+
       final state = showBiometricsButton != null
           ? Stream.value(showBiometricsButton)
           : Stream.value(false);
@@ -64,8 +64,6 @@ PinCodeBlocType pinCodeMockFactory({
   );
 
   when(service.verifyPinCode(Stubs.pinCode3)).thenAnswer((_) async => true);
-
-  when(service.isPinCodeInSecureStorage()).thenAnswer((_) async => true);
 
   when(service.encryptPinCode(Stubs.pinCode3))
       .thenAnswer((_) async => Stubs.pinCode3);


### PR DESCRIPTION
#### Overview
Removed `isPinCodeInSecureStorage` method from `PinCodeService`. Now this flag is set automatically when the pin code is saved in secure storage and accessed through the `getPinCode` method

#### Checklist

*Implementation*
- [ ] Implementation matches ticket acceptance criteria and technical notes
- [ ] Manually tested against Acceptance Criteria
- [ ] UI checked in Light / Dark mode

*Stability*
- [ ] Checked if changes affect any features and verified affected features work as expected
- [ ] Added unit tests for new code and verified existing tests work as expected

*Code quality*
- [ ] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [ ] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
- [ ] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes