### PR TITLE
Fix pin code key throwing a setState error

### DIFF
--- a/packages/widget_toolkit_pin/lib/src/lib_pin_code_with_biometrics/ui_components/pin_code_key.dart
+++ b/packages/widget_toolkit_pin/lib/src/lib_pin_code_with_biometrics/ui_components/pin_code_key.dart
@@ -48,9 +48,12 @@ class _PinCodeKeyState extends State<PinCodeKey> {
         onTapDown: widget.isLoading
             ? null
             : (_) async {
-                setState(() {
-                  isPressed = true;
-                });
+                if (mounted) {
+                  setState(() {
+                    isPressed = true;
+                  });
+                }
+
                 if (widget.isFingerScan || widget.isFaceScan) {
                   await Future.delayed(widget.tintDuration);
                 }
@@ -109,9 +112,11 @@ class _PinCodeKeyState extends State<PinCodeKey> {
       calculateKeyboardButtonSize(context);
 
   void _cancelPress() {
-    setState(() {
-      isPressed = false;
-    });
+    if (mounted) {
+      setState(() {
+        isPressed = false;
+      });
+    }
   }
 
   void _delayedButtonRelease() async {


### PR DESCRIPTION
This PR fixes an issue where holding a key down while the screen is being navigated would throw a setState error